### PR TITLE
Automatic update of Microsoft.EntityFrameworkCore.Tools to 5.0.4

### DIFF
--- a/MovieTinder/MovieTinder.csproj
+++ b/MovieTinder/MovieTinder.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.8">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
NuKeeper has generated a major update of `Microsoft.EntityFrameworkCore.Tools` to `5.0.4` from `3.1.8`
`Microsoft.EntityFrameworkCore.Tools 5.0.4` was published at `2021-03-09T14:27:42Z`, 10 days ago

1 project update:
Updated `MovieTinder\MovieTinder.csproj` to `Microsoft.EntityFrameworkCore.Tools` `5.0.4` from `3.1.8`

[Microsoft.EntityFrameworkCore.Tools 5.0.4 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Tools/5.0.4)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
