### PR TITLE
Automatic update of MySql.Data.EntityFrameworkCore to 8.0.22

### DIFF
--- a/MovieTinder/MovieTinder.csproj
+++ b/MovieTinder/MovieTinder.csproj
@@ -35,7 +35,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MySql.Data.EntityFrameworkCore" Version="8.0.21" />
+    <PackageReference Include="MySql.Data.EntityFrameworkCore" Version="8.0.22" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">


### PR DESCRIPTION
NuKeeper has generated a patch update of `MySql.Data.EntityFrameworkCore` to `8.0.22` from `8.0.21`
`MySql.Data.EntityFrameworkCore 8.0.22` was published at `2020-10-19T07:23:17Z`, 5 months ago

1 project update:
Updated `MovieTinder\MovieTinder.csproj` to `MySql.Data.EntityFrameworkCore` `8.0.22` from `8.0.21`

[MySql.Data.EntityFrameworkCore 8.0.22 on NuGet.org](https://www.nuget.org/packages/MySql.Data.EntityFrameworkCore/8.0.22)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
