### PR TITLE
Automatic update of Microsoft.TypeScript.MSBuild to 4.2.3

### DIFF
--- a/MovieTinder/MovieTinder.csproj
+++ b/MovieTinder/MovieTinder.csproj
@@ -31,7 +31,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="4.0.3">
+    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="4.2.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.TypeScript.MSBuild` to `4.2.3` from `4.0.3`
`Microsoft.TypeScript.MSBuild 4.2.3` was published at `2021-03-04T23:06:00Z`, 14 days ago

1 project update:
Updated `MovieTinder\MovieTinder.csproj` to `Microsoft.TypeScript.MSBuild` `4.2.3` from `4.0.3`

[Microsoft.TypeScript.MSBuild 4.2.3 on NuGet.org](https://www.nuget.org/packages/Microsoft.TypeScript.MSBuild/4.2.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
