### PR TITLE
Automatic update of 3 packages

### DIFF
--- a/MovieTinder/MovieTinder.csproj
+++ b/MovieTinder/MovieTinder.csproj
@@ -35,7 +35,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MySql.Data.EntityFrameworkCore" Version="8.0.21" />
+    <PackageReference Include="MySql.Data.EntityFrameworkCore" Version="8.0.22" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/MovieTinder/MovieTinder.csproj
+++ b/MovieTinder/MovieTinder.csproj
@@ -31,7 +31,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="4.0.3">
+    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="4.2.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/MovieTinder/MovieTinder.csproj
+++ b/MovieTinder/MovieTinder.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.8">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
3 packages were updated in 1 project:
`Microsoft.EntityFrameworkCore.Tools`, `MySql.Data.EntityFrameworkCore`, `Microsoft.TypeScript.MSBuild`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a major update of `Microsoft.EntityFrameworkCore.Tools` to `5.0.4` from `3.1.8`
`Microsoft.EntityFrameworkCore.Tools 5.0.4` was published at `2021-03-09T14:27:42Z`, 10 days ago

1 project update:
Updated `MovieTinder\MovieTinder.csproj` to `Microsoft.EntityFrameworkCore.Tools` `5.0.4` from `3.1.8`

[Microsoft.EntityFrameworkCore.Tools 5.0.4 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Tools/5.0.4)

NuKeeper has generated a patch update of `MySql.Data.EntityFrameworkCore` to `8.0.22` from `8.0.21`
`MySql.Data.EntityFrameworkCore 8.0.22` was published at `2020-10-19T07:23:17Z`, 5 months ago

1 project update:
Updated `MovieTinder\MovieTinder.csproj` to `MySql.Data.EntityFrameworkCore` `8.0.22` from `8.0.21`

[MySql.Data.EntityFrameworkCore 8.0.22 on NuGet.org](https://www.nuget.org/packages/MySql.Data.EntityFrameworkCore/8.0.22)

NuKeeper has generated a minor update of `Microsoft.TypeScript.MSBuild` to `4.2.3` from `4.0.3`
`Microsoft.TypeScript.MSBuild 4.2.3` was published at `2021-03-04T23:06:00Z`, 14 days ago

1 project update:
Updated `MovieTinder\MovieTinder.csproj` to `Microsoft.TypeScript.MSBuild` `4.2.3` from `4.0.3`

[Microsoft.TypeScript.MSBuild 4.2.3 on NuGet.org](https://www.nuget.org/packages/Microsoft.TypeScript.MSBuild/4.2.3)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
